### PR TITLE
Add permission check for update-database action

### DIFF
--- a/.github/workflows/update-database.yaml
+++ b/.github/workflows/update-database.yaml
@@ -31,6 +31,7 @@ jobs:
           echo "authorised=$AUTHORISED" >> $GITHUB_OUTPUT
 
   update-database:
+    needs: check-permission
     # If the workflow was triggered by closing an issue, only run if the issue contains the 'add-plugin' label.
     if: |
       needs.check-permission.outputs.authorised == 'true' &&

--- a/.github/workflows/update-database.yaml
+++ b/.github/workflows/update-database.yaml
@@ -10,9 +10,31 @@ on:
   push:
 
 jobs:
+  check-permission:
+    runs-on: ubuntu-latest
+    outputs:
+      authorised: ${{ steps.check-permission.outputs.authorised }}
+    steps:
+      - name: Determine if user has permission to update the database
+        id: check-permission
+        run: |
+          USER=${{ github.event.sender.login }}
+          REPO=${{ github.repository }}
+          RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/$REPO/collaborators/$USER/permission")
+          PERMISSION=$(echo "$RESPONSE" | sed -n 's/.*"permission": "\(.*\)".*/\1/p')
+          if [ "$PERMISSION" = "admin" ] || [ "$PERMISSION" = "maintain" ] || [ "$PERMISSION" = "write" ]; then
+            AUTHORISED="true"
+          else
+            AUTHORISED="false"
+          fi
+          echo "authorised=$AUTHORISED" >> $GITHUB_OUTPUT
+
   update-database:
     # If the workflow was triggered by closing an issue, only run if the issue contains the 'add-plugin' label.
-    if: ${{ github.event_name == 'workflow_dispatch' }} or ${{ github.event.label.name == 'add-plugin' }}
+    if: |
+      needs.check-permission.outputs.authorised == 'true' &&
+      (github.event_name == 'workflow_dispatch' || github.event.label.name == 'add-plugin')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo content
@@ -23,7 +45,7 @@ jobs:
       - name: Retrieve URL submission
         id: url
         run: |
-          if ${{ github.event_name == 'issues' }}; then
+          if [ "${{ github.event_name }}" == "issues" ]; then
             echo "url=${{ github.event.issue.body }}" >> $GITHUB_OUTPUT
           else
             echo "url=''" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+wheels/
+build/
+dist/
+*.egg-info/
+*.egg
+.eggs/
+
+# Intellij projects
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -17,3 +17,5 @@ MAP-Client users are able to submit their own MAP plugins to the MAP Plugin Data
 to submit an issue in the `MAP Plugin Database`_ GitHub repository. The issue should be tagged with the *add-plugin* label. The body of the
 issue submission should contain only the GitHub repository path of the plugin to be added; this path should be in the format:
 *{organization}/{repository}*, for example: *mapclient-plugins/pointsourcestep*.
+
+Editing database entries and triggering the automated processes to update this database are restricted to repository maintainers.


### PR DESCRIPTION
This ensures that the update-database GitHub action will only be run if the user closing the issue has the required permissions.